### PR TITLE
Fix for rails 4.2. Now recognizes app.config.serve_static_files. -RTV

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ It is disabled by default for `development` environments, but may be enabled the
 
     config.serve_static_assets = true
 
+As of Rails 4.2 `serve_static_assets` has been renamed to `serve_static_files`. You should use:
+
+    config.serve_static_assets = true
+
+if you are on Rails 4.2.
+
 
 ## Installation
 

--- a/lib/smart_assets/railtie.rb
+++ b/lib/smart_assets/railtie.rb
@@ -11,7 +11,7 @@ module SmartAssets
         prefix = app.config.smart_assets.prefix || app.config.assets.prefix || '/assets'
         cc = app.config.smart_assets.cache_control
 
-        if app.config.serve_static_assets || app.config.assets.compile
+        if app.config.serve_static_assets || app.config.assets.compile || app.config.serve_static_files
           app.middleware.insert_after(::Rack::Sendfile, SmartAssets::Rack, prefix, cc)
         end
       end

--- a/lib/smart_assets/version.rb
+++ b/lib/smart_assets/version.rb
@@ -1,3 +1,3 @@
 module SmartAssets
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end


### PR DESCRIPTION
Rails 4.2 is deprecating 'config.serve_static_assets' in order to rename it 'config.serve_static_files'.  Added to the check for 'config.serve_static_assets' to also recognize 'config.serve_static_files' and allow smart_assets to work on Rails 4.2 when using the new 'config.serve_static_files'.