### PR TITLE
gemspec: Drop unused #test_files and #executables

### DIFF
--- a/smart_assets.gemspec
+++ b/smart_assets.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'rails', '>= 4.0', '< 6'


### PR DESCRIPTION
This drops unused generated cruft.